### PR TITLE
Add code for auto adding steam_appid.txt file

### DIFF
--- a/Modules/AddSteamID.cs
+++ b/Modules/AddSteamID.cs
@@ -1,0 +1,20 @@
+﻿using System.IO;
+using static TOHE.Translator;
+
+namespace TOHE;
+
+public class AddSteamID
+{
+        private static readonly string FilePath = @"./steam_appid.txt";
+        public static void AddSteamAppIdFile()
+        {
+            if (!File.Exists(FilePath))
+            {
+            Logger.Warn("Creating a new steam_appid.txt file", "AddSteamID");
+            File.Create(FilePath).Close();
+            File.WriteAllText(FilePath, "945360");
+
+            ModUpdater.ShowPopup(GetString("AppIDAdded"), StringNames.Close, true, true);
+            }
+        }
+}

--- a/Modules/ModUpdater.cs
+++ b/Modules/ModUpdater.cs
@@ -319,7 +319,7 @@ public class ModUpdater
     {
     }
 
-    private static void ShowPopup(string message, StringNames buttonText, bool showButton = false, bool buttonIsExit = true)
+    public static void ShowPopup(string message, StringNames buttonText, bool showButton = false, bool buttonIsExit = true)
     {
         if (InfoPopup == null) return;
 

--- a/Resources/Lang/en_US.json
+++ b/Resources/Lang/en_US.json
@@ -2100,6 +2100,7 @@
   "announcementChangelog": "<size=3f>ChangeLogs v{0}</size>\\n{1}",
   "updateRestart": "Update Finished!\\nPlease restart the game.",
   "updateFailed": "Update failed.",
+  "AppIDAdded": "Since there was no steam_appid.txt file, a new one was created to prevent errors. \\nPlease restart the game to apply changes.",
   "downloadFailed": "Failed to upload file! \\nPlease try again later or restart the game...",
   "onSetPublicNoLatest": "Public rooms are only available in the latest version.\\nPlease update.",
   "CanNotJoinPublicRoomNoLatest": "You can't join public rooms without the latest version.\\nPlease update.",

--- a/Resources/Lang/pt_BR.json
+++ b/Resources/Lang/pt_BR.json
@@ -2068,6 +2068,7 @@
   "announcementChangelog": "<size=3f>Mudanças v{0}</size>\\n{1}",
   "updateRestart": "Atualização Finalizada!\\nPor favor reinicie o jogo.",
   "updateFailed": "Falha na Atualização.",
+  "AppIDAdded": "Já que não havia nenhum arquivo chamado steam_appid.txt, um novo foi criado para prevenir erros. \\nPor favor reinicie o jogo para aplicar as alterações.",
   "downloadFailed": "Falha em baixar o arquivo! \\nTente de novo mais tarde ou reinicie o jogo...",
   "onSetPublicNoLatest": "Salas públicas só estão disponíveis na última versão.\\nPor favor atualize.",
   "CanNotJoinPublicRoomNoLatest": "Você não pode entrar em salas públicas com essa versão.\\nPor favor atualize.",


### PR DESCRIPTION
this is for when u DONT install the mod in steam directory, and if the steam_appid.txt file dont get copied

so, i made this to automatically add the steam_appid file and writing the appID from Among Us

**NOTE: this is only for Steam users**